### PR TITLE
adapt correlate to trekkie and locations stored in DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,17 @@
 # Changelog
 
 ## Unreleased
+
 ### Breaking
+
+Old correlation function deleted
+
+Type aliases removed
+
 ### New
+
+Add correlation function to work with trekkie and db-stored data
+
 ### Misc
 
 ## 0.3.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,9 +325,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+checksum = "280a9f2d8b3a38871a3c8a46fb80db65e5e5ed97da80c4d08bf27fb63e35e181"
 dependencies = [
  "libc",
 ]
@@ -839,9 +839,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -964,6 +964,7 @@ dependencies = [
  "serde_json",
  "stderrlog",
  "tlms",
+ "uuid",
 ]
 
 [[package]]
@@ -1096,9 +1097,9 @@ checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "openssl"
-version = "0.10.47"
+version = "0.10.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b277f87dacc05a6b709965d1cbafac4649d6ce9f3ce9ceb88508b5666dfec9"
+checksum = "518915b97df115dd36109bfa429a48b8f737bd05508cf9588977b599648926d2"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
@@ -1128,9 +1129,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.82"
+version = "0.9.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a95792af3c4e0153c3914df2261bedd30a98476f94dc892b67dfe1d89d433a04"
+checksum = "666416d899cf077260dac8698d60a60b435a46d57e82acb1be3d0dad87284e5b"
 dependencies = [
  "autocfg",
  "cc",
@@ -1419,9 +1420,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.2"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cce168fea28d3e05f158bda4576cf0c844d5045bc2cc3620fa0292ed5bb5814c"
+checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1790,7 +1791,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "tlms"
 version = "0.9.0"
-source = "git+https://github.com/tlm-solutions/tlms.rs#53bcf41c3dbd69703c27e6848eedacf1fe93e8b6"
+source = "git+https://github.com/tlm-solutions/tlms.rs#303b85e973701d29c095da7db2a47ec1844edd26"
 dependencies = [
  "chrono",
  "csv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ name = "lofi"
 path = "src/lib.rs"
 
 [features]
+default = [ "correlate" ]
 build-binary = [
     "correlate",
     "filter",
@@ -25,6 +26,7 @@ correlate = [
     "tlms/locations",
     "tlms/telegrams",
     "serde_json",
+    "uuid"
 ]
 filter = [
     "tlms/measurements",
@@ -40,5 +42,6 @@ csv = { version = "1.1.6", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "*", optional = true }
 geojson = { version = "0.24", optional = true }
+uuid = {version = "1.2", features = ["serde", "v4"], optional = true}
 log = "0.4"
 stderrlog = "0.5.3"

--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1679472241,
-        "narHash": "sha256-VK2YDic2NjPvfsuneJCLIrWS38qUfoW8rLLimx0rWXA=",
+        "lastModified": 1679710833,
+        "narHash": "sha256-9yKVvGX1oAnlc8vTVvN2lRH35q6ETudQbM1w9ragMRU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9ef6e7727f4c31507627815d4f8679c5841efb00",
+        "rev": "83607dae4e05e1de755bbc7d7949b33fc1cfbbb9",
         "type": "github"
       },
       "original": {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,10 +2,6 @@
 //! this library provides the correlation facility to infer the location where r09 telegram was
 //! transmitted. You most probably want to look at [`crate::correlate`]
 
-/// Smol module for type aliases
-#[cfg(any(feature = "correlate", feature = "filter"))]
-pub mod types;
-
 /// Tools to correlate telegrams to positions.
 #[cfg(feature = "correlate")]
 pub mod correlate;

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,7 +85,6 @@ struct MergeArgs {
     first: String,
     #[clap(short, long, required = true)]
     second: String,
-
 }
 
 #[derive(Args, Debug)]
@@ -189,9 +188,15 @@ fn merge(opts: MergeArgs) {
     let mut old_stops = LocationsJson::from_file(&opts.first).expect("first file broken");
     let new_stops = LocationsJson::from_file(&opts.second).expect("second file broken");
 
-    let region_cache = LocationsJson::update_region_cache("https://datacare.dvb.solutions/", "/home/grue/.config/lofi".into()).expect("lol");
+    let region_cache = LocationsJson::update_region_cache(
+        "https://datacare.dvb.solutions/",
+        "/home/grue/.config/lofi".into(),
+    )
+    .expect("lol");
 
-    old_stops.merge(&new_stops, region_cache.metadata).expect("lol");
+    old_stops
+        .merge(&new_stops, region_cache.metadata)
+        .expect("lol");
     let stops_json = serde_json::to_string_pretty(&old_stops).expect("cannot put lipstic on a pig");
     println!("{stops_json}");
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,4 +1,0 @@
-use tlms::telegrams::r09::R09SaveTelegram;
-
-/// Type alias for boxed iterator over [`R09SaveTelegram`]
-pub type R09Iter = Box<dyn Iterator<Item = R09SaveTelegram>>;


### PR DESCRIPTION
## Things Changed

This provides a `correlate::correlate_trekkie` function to work on trekkie runs and give data that's ready for insertion into db.

For the time being, all other features including the standalone binary are broken ¯\_(ツ)_/¯

## Required Doc/Changelog Updates

- [X] **I HAVE UPDATED CHANGELOG ACCORDINGLY**
- [X] **I HAVE UPDATED DOCS ACCORDINGLY**
